### PR TITLE
Enables user kcen for bencher 2025

### DIFF
--- a/2025/config.toml
+++ b/2025/config.toml
@@ -30,13 +30,13 @@ language = "rust"
 input_cmd = "ci/scripts/input_path.sh"
 entrypoint = "lanjian-aoc run"
 
-# [participants.kcen]
-# username = "kcen"
-# repo = "https://github.com/kcen/aoc2025"
-# location = "kcen"
-# language = "nim"
-# input_cmd = "ci/scripts/input_path.sh"
-# entrypoint = "kcen-aoc"
+[participants.kcen]
+username = "kcen"
+repo = "https://github.com/kcen/aoc2025"
+location = "kcen"
+language = "nim"
+input_cmd = "ci/scripts/input_path.sh"
+entrypoint = "kcen-aoc"
 
 # [participants.mikofo]
 # username = "mikofo"

--- a/2025/pipeline.yaml
+++ b/2025/pipeline.yaml
@@ -93,16 +93,16 @@ resources:
     tags:
       - internal
 
-  # - name: kcen-bin
-  #   type: gitea-package
-  #   icon: package-up
-  #   source:
-  #     uri: ((gitea-package.uri))
-  #     owner: ((gitea-package.owner))
-  #     token: ((gitea-package.token))
-  #     package: kcen-aoc-2025
-  #   tags:
-  #     - internal
+  - name: kcen-bin
+    type: gitea-package
+    icon: package-up
+    source:
+      uri: ((gitea-package.uri))
+      owner: ((gitea-package.owner))
+      token: ((gitea-package.token))
+      package: kcen-aoc-2025
+    tags:
+      - internal
 
   - name: aoc-inputs
     type: git
@@ -168,14 +168,14 @@ resources:
         - 'README.md'
         - 'template/*'
 
-  # - name: kcen
-  #   type: git
-  #   icon: github
-  #   source:
-  #     uri: https://github.com/kcen/aoc2025
-  #     branch: main
-  #     ignore_paths:
-  #       - 'README.md'
+  - name: kcen
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/kcen/aoc2025
+      branch: main
+      ignore_paths:
+        - 'README.md'
 
   # - name: mikofo
   #   type: git
@@ -207,8 +207,8 @@ jobs:
           trigger: true
         - get: whyando
           trigger: true
-        # - get: kcen
-        #   trigger: true
+        - get: kcen
+          trigger: true
         # - get: mikofo
         #   trigger: true
         - get: aoc-inputs-write
@@ -568,82 +568,82 @@ jobs:
           # override this to be our check script
           check-input-script: "ci/2025/scripts/whyando-check.sh"
 
-  # - name: kcen-build
-  #   <<: *job-common
-  #   plan:
-  #     - in_parallel:
-  #       - get: ci
-  #         trigger: false
-  #       - get: kcen
-  #         trigger: true
-  #         passed:
-  #           - collect-inputs
+  - name: kcen-build
+    <<: *job-common
+    plan:
+      - in_parallel:
+        - get: ci
+          trigger: false
+        - get: kcen
+          trigger: true
+          passed:
+            - collect-inputs
 
-  #     - task: build
-  #       file: ci/2025/tasks/kcen-build-task.yaml
-  #       tags:
-  #         - internal
-  #         - ser6
-  #       input_mapping:
-  #         repo: kcen
+      - task: build
+        file: ci/2025/tasks/kcen-build-task.yaml
+        tags:
+          - internal
+          - ser6
+        input_mapping:
+          repo: kcen
 
-  #     - task: package
-  #       file: ci/2025/tasks/kcen-package.yaml
-  #       tags:
-  #         - internal
-  #       output_mapping:
-  #         release: gnu-release
+      - task: package
+        file: ci/2025/tasks/kcen-package.yaml
+        tags:
+          - internal
+        output_mapping:
+          release: gnu-release
 
-  #     - load_var: bin-version
-  #       file: gnu-release/VERSION
+      - load_var: bin-version
+        file: gnu-release/VERSION
 
-  #     - load_var: gnu-file
-  #       file: gnu-release/ARCHIVE_NAME
+      - load_var: gnu-file
+        file: gnu-release/ARCHIVE_NAME
 
-  #     - put: kcen-bin
-  #       tags:
-  #         - internal
-  #       inputs:
-  #         - gnu-release
-  #       params:
-  #         version: ((.:bin-version))
-  #         files:
-  #           - gnu-release/((.:gnu-file))
+      - put: kcen-bin
+        tags:
+          - internal
+        inputs:
+          - gnu-release
+        params:
+          version: ((.:bin-version))
+          files:
+            - gnu-release/((.:gnu-file))
 
-  # - name: kcen-check-inputs
-  #   <<: *job-common
-  #   plan:
-  #     - in_parallel:
-  #       - get: ci
-  #         trigger: false
-  #       - get: kcen-bin
-  #         trigger: true
-  #         tags:
-  #           - internal
-  #         passed:
-  #           - kcen-build
-  #       - get: aoc-tools
-  #         trigger: false
-  #         tags:
-  #           - internal
-  #       - get: aoc-inputs
-  #         trigger: true
-  #         passed:
-  #           - solve-inputs
-  #       - get: aoc-inputs-write
-  #         trigger: false
+  - name: kcen-check-inputs
+    <<: *job-common
+    plan:
+      - in_parallel:
+        - get: ci
+          trigger: false
+        - get: kcen-bin
+          trigger: true
+          tags:
+            - internal
+          passed:
+            - kcen-build
+        - get: aoc-tools
+          trigger: false
+          tags:
+            - internal
+        - get: aoc-inputs
+          trigger: true
+          passed:
+            - solve-inputs
+        - get: aoc-inputs-write
+          trigger: false
 
-  #     - task: check-inputs
-  #       file: ci/2025/tasks/check-inputs.yaml
-  #       tags:
-  #         - internal
-  #       input_mapping:
-  #         repo: kcen-bin
-  #       params:
-  #         PARTICIPANT: "kcen"
-  #       vars:
-  #         # override this to be our check script
-  #         check-input-script: "ci/2025/scripts/kcen-check.sh"
+      - task: check-inputs
+        file: ci/2025/tasks/check-inputs.yaml
+        tags:
+          - internal
+        input_mapping:
+          repo: kcen-bin
+        params:
+          PARTICIPANT: "kcen"
+        vars:
+          # override this to be our check script
+          check-input-script: "ci/2025/scripts/kcen-check.sh"
 
   # - name: mikofo-build
   #   <<: *job-common
@@ -734,12 +734,12 @@ jobs:
             - internal
           passed:
             - whyando-check-inputs
-        # - get: kcen-bin
-        #   trigger: true
-        #   tags:
-        #     - internal
-        #   passed:
-        #     - kcen-check-inputs
+        - get: kcen-bin
+          trigger: true
+          tags:
+            - internal
+          passed:
+            - kcen-check-inputs
         # - get: mikofo
         #   trigger: true
         #   passed:

--- a/2025/tasks/collect-inputs.yaml
+++ b/2025/tasks/collect-inputs.yaml
@@ -14,7 +14,7 @@ inputs:
   - name: mattcl-py
   - name: lanjian
   - name: whyando
-  # - name: kcen
+  - name: kcen
   # - name: mikofo
 
 outputs:

--- a/2025/tasks/comparative-benchmarks.yaml
+++ b/2025/tasks/comparative-benchmarks.yaml
@@ -14,7 +14,7 @@ inputs:
   - name: mattcl-py
   - name: lanjian-bin
   - name: whyando-bin
-  # - name: kcen-bin
+  - name: kcen-bin
   # - name: mikofo
 
 outputs:

--- a/2025/tasks/kcen-build-task.yaml
+++ b/2025/tasks/kcen-build-task.yaml
@@ -2,8 +2,9 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: mattcl/aoc-ci-bencher
-    tag: latest
+    # TODO: Consider updating aoc-bencher to Debian trixie (so this #just_works on nim 2.2.4)
+    repository: nimlang/nim
+    tag: 2.2.4-alpine-slim
 
 inputs:
   - name: ci


### PR DESCRIPTION
Enables user kcen for benchmarks 2025, not totally tested.

Uncomments pre-setup stufff, as well as changes builder image to `nimlang/nim:2.2.4-alpine-slim`

**Need to change the CI-builder because nim 2 is only available in Debian trixie or newer (testing)